### PR TITLE
Fixed authorization error on systems with >1 loopback interfaces

### DIFF
--- a/src/net/x.java
+++ b/src/net/x.java
@@ -14,7 +14,7 @@ public class x {
             if (g == null) {
                 g = m.group(1);
             }
-        	return g == null ? g : g.replace('-', ':');
+        	return g == null ? g : g.replace("-", "");
         }
         return null;
     }

--- a/src/net/y.java
+++ b/src/net/y.java
@@ -223,6 +223,10 @@ public final class y {
 
     //}
     private static void close(BufferedReader in, InputStream errorStream, OutputStream outputStream) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        try {
+            in.close();
+        } catch (IOException e) {
+            
+        }
     }
 }


### PR DESCRIPTION
Due to Java bug (https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6798979#) NetworkInterface.getNetworkInterfaces() method returns an incomplete list of network interfaces and the launcher should obtain MAC address for settings encryption from other sources. This patch fixes "ipconfig /all" method.